### PR TITLE
feat: implementar cadastro de modelos e fluxo de deteccao

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -117,6 +117,28 @@ Atualiza a confirmação do defeito.
 Multipart:
 
 - `file`: imagem, ZIP ou vídeo
-- `placaId`: opcional
-- `placaCodigo`: opcional, usado como `modelo.codigo`
+- `modelo_codigo`: obrigatorio para validar o modelo selecionado
 - `classes`: opcional
+
+Retorna apenas a analise temporaria, sem persistir no banco.
+
+### `POST /api/detection/save`
+
+Body JSON:
+
+```json
+{
+  "modelo_codigo": "PCB-A001-L1",
+  "source_type": "imagem",
+  "detections": [
+    {
+      "class_id": 0,
+      "label": "R/CFaltante",
+      "confidence": 0.97,
+      "bbox": [10, 20, 100, 120]
+    }
+  ]
+}
+```
+
+Cria uma nova placa vinculada ao modelo informado e persiste as deteccoes somente quando o usuario confirma o salvamento.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ O backend executa `prisma migrate deploy` no startup.
 - `GET, POST /api/defeitos`
 - `PUT /api/defeitos`
 - `GET, POST /api/detection`
+- `POST /api/detection/save`
 - `GET /api/swagger`
 
 ## Validação

--- a/app/configuracoes/page.js
+++ b/app/configuracoes/page.js
@@ -1,53 +1,153 @@
 'use client'
-import { useEffect, useState } from 'react'
+
+import { useEffect, useMemo, useState } from 'react'
 import AppShell from '@/components/AppShell'
 import { api } from '@/services/api'
+import { toast } from 'sonner'
 
-export default function AjustesPage() {
-  const [health, setHealth] = useState(null)
+export default function AdministracaoModelosPage() {
+  const [models, setModels] = useState([])
+  const [codigo, setCodigo] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const totalPlacas = useMemo(() => models.reduce((acc, modelo) => acc + (Array.isArray(modelo.placas) ? modelo.placas.length : 0), 0), [models])
+
+  const loadModels = async () => {
+    setIsLoading(true)
+    setError('')
+
+    try {
+      const data = await api.getModelos()
+      setModels(Array.isArray(data) ? data : [])
+    } catch (err) {
+      const message = err.message || 'Erro ao carregar modelos'
+      setError(message)
+      toast.error(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   useEffect(() => {
-    api.getHealth().then(setHealth).catch(() => setHealth(null))
+    loadModels()
   }, [])
 
+  const handleCreate = async (event) => {
+    event.preventDefault()
+
+    const codigoModelo = codigo.trim()
+    if (!codigoModelo) {
+      toast.error('Informe o codigo do modelo')
+      return
+    }
+
+    if (models.some((modelo) => modelo.codigo === codigoModelo)) {
+      toast.error('Codigo de modelo ja existe')
+      return
+    }
+
+    try {
+      setIsSaving(true)
+      const created = await api.criarModelo({ codigo: codigoModelo })
+      setModels((current) => [created, ...current.filter((modelo) => modelo.codigo !== created.codigo)].sort((a, b) => a.codigo.localeCompare(b.codigo)))
+      setCodigo('')
+      toast.success('Modelo cadastrado com sucesso')
+    } catch (err) {
+      toast.error(err.message || 'Erro ao cadastrar modelo')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   return (
-    <AppShell breadcrumb="Sistema / Ajustes">
-      <div className="p-8 max-w-2xl mx-auto space-y-12">
-        <header>
-          <h2 className="text-2xl font-black text-white uppercase italic">Configurações</h2>
-          <p className="text-[9px] text-white/20 uppercase tracking-[0.4em] font-mono">Terminal Profile & Core Connection</p>
+    <AppShell breadcrumb="Controle / Modelos">
+      <div className="p-8 max-w-6xl mx-auto space-y-8">
+        <header className="space-y-2">
+          <h2 className="text-3xl font-black text-white uppercase italic tracking-tight">Administração de modelos</h2>
+          <p className="text-[9px] text-white/20 uppercase tracking-[0.35em] font-mono">Cadastro persistido diretamente na tabela modelo</p>
         </header>
 
-        <section className="space-y-6">
-          <div className="space-y-4 border-l-2 border-fuchsia-500 pl-6">
-            <h4 className="text-[10px] font-black text-white uppercase tracking-widest">Identificação do Operador</h4>
-            <div className="grid gap-4">
-              <input type="text" placeholder="Nome Completo" className="bg-white/5 border border-white/10 p-3 rounded text-[11px] outline-none focus:border-fuchsia-500 transition-colors" />
-              <input type="text" placeholder="Matrícula / ID" className="bg-white/5 border border-white/10 p-3 rounded text-[11px] outline-none focus:border-fuchsia-500 transition-colors" />
+        <section className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-6">
+          <form onSubmit={handleCreate} className="bg-white/[0.02] border border-white/10 rounded-3xl p-6 space-y-4 shadow-xl">
+            <div className="space-y-2">
+              <p className="text-[10px] font-black text-white uppercase tracking-widest">Novo modelo</p>
+              <p className="text-[11px] text-white/40 font-mono">O codigo precisa ser unico e vai direto para o banco.</p>
             </div>
-          </div>
 
-          <div className="space-y-4 border-l-2 border-white/10 pl-6">
-            <h4 className="text-[10px] font-black text-white uppercase tracking-widest">Conexão com o Servidor</h4>
-            <div className="grid gap-4">
-              <div className="flex gap-2">
-                <input type="text" placeholder="IP do Host" defaultValue="192.168.1.104" className="flex-1 bg-white/5 border border-white/10 p-3 rounded text-[11px] font-mono text-fuchsia-500 outline-none" />
-                <input type="text" placeholder="Porta" defaultValue="8000" className="w-24 bg-white/5 border border-white/10 p-3 rounded text-[11px] font-mono text-fuchsia-500 outline-none" />
+            <label className="block space-y-2">
+              <span className="text-[10px] uppercase font-black text-white/60 tracking-widest">Codigo do modelo</span>
+              <input
+                value={codigo}
+                onChange={(event) => setCodigo(event.target.value)}
+                placeholder="PCB-A001-L1"
+                className="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-sm font-mono text-white outline-none focus:border-fuchsia-500 transition-colors"
+              />
+            </label>
+
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="w-full py-3 bg-fuchsia-500 text-black font-mono text-[10px] font-black uppercase rounded-xl hover:bg-fuchsia-400 disabled:opacity-50 transition-all"
+            >
+              {isSaving ? 'Salvando...' : 'Cadastrar modelo'}
+            </button>
+
+            <button
+              type="button"
+              onClick={loadModels}
+              disabled={isLoading}
+              className="w-full py-3 bg-white/5 border border-white/10 text-white font-mono text-[10px] font-black uppercase rounded-xl hover:border-fuchsia-500 transition-all disabled:opacity-50"
+            >
+              Atualizar listagem
+            </button>
+
+            <div className="pt-2 border-t border-white/10 space-y-1">
+              <p className="text-[10px] uppercase font-black text-white/60 tracking-widest">Resumo</p>
+              <p className="text-[11px] font-mono text-white/40">Modelos cadastrados: {isLoading ? '-' : models.length}</p>
+              <p className="text-[11px] font-mono text-white/40">Placas vinculadas: {isLoading ? '-' : totalPlacas}</p>
+              {error && <p className="text-[11px] font-mono text-red-300">{error}</p>}
+            </div>
+          </form>
+
+          <div className="bg-white/[0.02] border border-white/10 rounded-3xl overflow-hidden shadow-xl">
+            <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-white/10 bg-white/[0.02]">
+              <div>
+                <p className="text-[10px] font-black text-white uppercase tracking-widest">Modelos persistidos</p>
+                <p className="text-[11px] text-white/40 font-mono">Listagem diretamente do banco de dados</p>
               </div>
+              <p className="text-[10px] font-mono text-white/40 uppercase">{isLoading ? 'Carregando...' : `${models.length} registros`}</p>
+            </div>
+
+            <div className="divide-y divide-white/10">
+              {isLoading ? (
+                Array.from({ length: 4 }).map((_, index) => (
+                  <div key={index} className="px-6 py-4 animate-pulse">
+                    <div className="h-4 w-48 bg-white/10 rounded mb-2"></div>
+                    <div className="h-3 w-24 bg-white/10 rounded"></div>
+                  </div>
+                ))
+              ) : models.length > 0 ? (
+                models.map((modelo) => (
+                  <div key={modelo.codigo} className="px-6 py-4 flex items-center justify-between gap-4 hover:bg-white/[0.03] transition-colors">
+                    <div>
+                      <p className="text-sm font-black text-white uppercase tracking-tight">{modelo.codigo}</p>
+                      <p className="text-[11px] text-white/35 font-mono">{Array.isArray(modelo.placas) ? modelo.placas.length : 0} placa(s) vinculada(s)</p>
+                    </div>
+                    <span className="px-3 py-1 rounded-full border border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-300 font-mono text-[10px] uppercase font-black">
+                      modelo
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <div className="px-6 py-10 text-center">
+                  <p className="text-sm text-white/50 font-mono uppercase">Nenhum modelo cadastrado</p>
+                </div>
+              )}
             </div>
           </div>
         </section>
-
-        <button className="w-full py-3 bg-white text-black font-mono text-[10px] font-black uppercase rounded hover:bg-fuchsia-500 hover:text-white transition-all">
-          Salvar Alterações
-        </button>
-
-        <div className="bg-white/5 border border-white/10 rounded-xl p-4">
-          <p className="text-[10px] font-black uppercase text-white/70 mb-1">Saúde dos serviços</p>
-          <p className="text-[11px] text-white/40 font-mono">API: {health?.api || 'indisponivel'}</p>
-          <p className="text-[11px] text-white/40 font-mono">Database: {health?.database || 'indisponivel'}</p>
-          <p className="text-[11px] text-white/40 font-mono">IA: {health?.ai?.status || 'indisponivel'}</p>
-        </div>
       </div>
     </AppShell>
   )

--- a/app/imagens/page.js
+++ b/app/imagens/page.js
@@ -5,7 +5,6 @@ import AppShell from '@/components/AppShell'
 import { api } from '@/services/api'
 import { toast } from 'sonner'
 
-const DEFAULT_PLACA_CODIGO = 'PCB-AUTO-001'
 const MODEL_PATH = 'runs/detect/train/weights/best.pt'
 const VIDEO_EXTENSIONS = ['.mp4', '.mov', '.avi', '.mkv', '.webm']
 
@@ -26,13 +25,20 @@ function normalizeBBox(bbox) {
 
 export default function InspecaoImagens() {
   const [imageFile, setImageFile] = useState(null)
+  const [models, setModels] = useState([])
+  const [selectedModelCodigo, setSelectedModelCodigo] = useState('')
   const [isAnalyzing, setIsAnalyzing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
   const [detections, setDetections] = useState([])
+  const [savedDetections, setSavedDetections] = useState([])
+  const [savedPlaca, setSavedPlaca] = useState(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [statusText, setStatusText] = useState('Aguardando imagem ou lote')
   const [errorText, setErrorText] = useState('')
   const [availableClasses, setAvailableClasses] = useState([])
+  const [fallbackClasses, setFallbackClasses] = useState([])
   const [selectedClasses, setSelectedClasses] = useState([])
+  const [analysisMeta, setAnalysisMeta] = useState(null)
 
   const fileInputRef = useRef(null)
   const originalCanvasRef = useRef(null)
@@ -66,6 +72,15 @@ export default function InspecaoImagens() {
   }, [selectedImageUrl])
 
   useEffect(() => {
+    const loadModels = async () => {
+      try {
+        const data = await api.getModelos()
+        setModels(Array.isArray(data) ? data : [])
+      } catch (error) {
+        toast.error(error.message)
+      }
+    }
+
     const loadDefectClasses = async () => {
       try {
         const response = await fetch('/api/defect-classes', { cache: 'no-store' })
@@ -75,14 +90,42 @@ export default function InspecaoImagens() {
         }
 
         const classes = Array.isArray(payload?.data?.classes) ? payload.data.classes : []
+        setFallbackClasses(classes)
         setAvailableClasses(classes)
+        setSelectedClasses((current) => (current.length > 0 ? current : classes))
       } catch (error) {
         toast.error(error.message)
       }
     }
 
+    loadModels()
     loadDefectClasses()
   }, [])
+
+  useEffect(() => {
+    const loadModelDefects = async () => {
+      if (!selectedModelCodigo) {
+        setAvailableClasses(fallbackClasses)
+        setSelectedClasses((current) => (current.length > 0 ? current.filter((item) => fallbackClasses.includes(item)) : fallbackClasses))
+        return
+      }
+
+      try {
+        const defeitos = await api.getDefeitos({ modelo_codigo: selectedModelCodigo })
+        const classesFromDb = Array.from(new Set(defeitos.map((item) => item?.classe_defeito).filter(Boolean))).sort()
+        const nextClasses = classesFromDb.length > 0 ? classesFromDb : fallbackClasses
+        setAvailableClasses(nextClasses)
+        setSelectedClasses((current) => {
+          const intersection = current.filter((item) => nextClasses.includes(item))
+          return intersection.length > 0 ? intersection : nextClasses
+        })
+      } catch (error) {
+        toast.error(error.message)
+      }
+    }
+
+    loadModelDefects()
+  }, [selectedModelCodigo, fallbackClasses])
 
   useEffect(() => {
     if (!selectedImageUrl) {
@@ -248,6 +291,9 @@ export default function InspecaoImagens() {
   const clearImage = () => {
     setImageFile(null)
     setDetections([])
+    setSavedDetections([])
+    setSavedPlaca(null)
+    setAnalysisMeta(null)
     setSelectedIndex(0)
     setStatusText('Aguardando imagem ou lote')
     setErrorText('')
@@ -288,9 +334,13 @@ export default function InspecaoImagens() {
       return
     }
 
+    if (!selectedModelCodigo || models.length === 0) {
+      toast.error('Selecione um modelo de placa')
+      return
+    }
+
     const classesArray = [...selectedClasses]
     if (classesArray.length === 0) {
-      setErrorText('Selecione ao menos um defeito')
       setStatusText('Aguardando processamento')
       toast.error('Selecione ao menos um defeito')
       return
@@ -301,11 +351,13 @@ export default function InspecaoImagens() {
       setErrorText('')
       setStatusText('Processando...')
       setDetections([])
+      setSavedDetections([])
+      setSavedPlaca(null)
       setSelectedIndex(0)
 
       const formData = new FormData()
       formData.append('file', imageFile)
-      formData.append('placaCodigo', DEFAULT_PLACA_CODIGO)
+      formData.append('modelo_codigo', selectedModelCodigo)
       
       if (classesArray.length > 0) {
         formData.append('classes', JSON.stringify(classesArray))
@@ -315,25 +367,94 @@ export default function InspecaoImagens() {
 
       const nextDetections = Array.isArray(result.detections) ? result.detections : []
       setDetections(nextDetections)
+      setAnalysisMeta({ inputType: result.inputType || 'imagem' })
       setSelectedIndex(0)
-      setStatusText('Deteccao concluida')
+      setStatusText('Deteccao concluida. Aguardando salvamento explicito')
       toast.success('Deteccao concluida com sucesso')
     } catch (error) {
       setStatusText('Aguardando imagem ou lote')
-      toast.error(error.message)
+      setErrorText(error.message || 'Nao foi possivel processar a imagem')
+      toast.error(error.message || 'Nao foi possivel processar a imagem')
     } finally {
       setIsAnalyzing(false)
     }
+  }
+
+  const saveDetections = async () => {
+    if (!selectedModelCodigo) {
+      toast.error('Selecione um modelo antes de salvar')
+      return
+    }
+
+    if (!detections.length) {
+      toast.error('Nao ha deteccoes temporarias para salvar')
+      return
+    }
+
+    try {
+      setIsSaving(true)
+      const result = await api.salvarDeteccoes({
+        modelo_codigo: selectedModelCodigo,
+        detections,
+        source_type: analysisMeta?.inputType || (String(imageFile?.type || '').startsWith('video/') ? 'video' : 'imagem'),
+      })
+
+      const persisted = Array.isArray(result?.savedDefeitos) ? result.savedDefeitos : []
+      setSavedDetections(persisted)
+      setSavedPlaca(result?.placa || null)
+      setStatusText(`Deteccoes salvas na placa ${result?.placa?.id || ''}`.trim())
+      toast.success('Deteccoes salvas com sucesso')
+
+      const defeitosAtualizados = await api.getDefeitos({ modelo_codigo: selectedModelCodigo })
+      const classesAtualizadas = Array.from(new Set(defeitosAtualizados.map((item) => item?.classe_defeito).filter(Boolean))).sort()
+      if (classesAtualizadas.length > 0) {
+        setAvailableClasses(classesAtualizadas)
+        setSelectedClasses((current) => {
+          const intersection = current.filter((item) => classesAtualizadas.includes(item))
+          return intersection.length > 0 ? intersection : classesAtualizadas
+        })
+      }
+    } catch (error) {
+      toast.error(error.message)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const cancelDetections = () => {
+    setDetections([])
+    setSavedDetections([])
+    setSavedPlaca(null)
+    setAnalysisMeta(null)
+    setSelectedIndex(0)
+    setStatusText('Deteccoes temporarias descartadas')
+    toast.info('Deteccoes descartadas')
   }
 
   return (
     <AppShell breadcrumb="Análise / Scanner de PCBs">
       <div className="p-6 h-[calc(100vh-48px)] flex flex-col gap-6 overflow-hidden relative">
         <span className="sr-only">Imagem para analise</span>
-        <span className="sr-only">Codigo da placa</span>
+        <span className="sr-only">Codigo do modelo selecionado</span>
         <span className="sr-only">Defeitos persistidos</span>
         <div className="flex flex-wrap items-center justify-between gap-3 bg-bg-panel border border-border p-4 rounded-2xl shadow-xl shrink-0">
           <div className="flex items-center gap-3">
+            <div className="min-w-[240px]">
+              <p className="text-[9px] text-text-muted uppercase font-mono mb-1">Modelo da placa</p>
+              <select
+                value={selectedModelCodigo}
+                onChange={(event) => setSelectedModelCodigo(event.target.value)}
+                className={`w-full bg-bg-elevated border border-border font-mono text-[10px] font-black uppercase rounded-lg px-3 py-2.5 outline-none focus:border-amber transition-colors ${selectedModelCodigo ? 'text-text-primary' : 'text-red-500'}`}
+              >
+                <option value="">Selecione um modelo cadastrado</option>
+                {models.map((modelo) => (
+                  <option key={modelo.codigo} value={modelo.codigo}>
+                    {modelo.codigo}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <input
               ref={fileInputRef}
               type="file"
@@ -360,7 +481,7 @@ export default function InspecaoImagens() {
 
             <button
               onClick={runDetection}
-              disabled={isAnalyzing || !imageFile}
+                disabled={isAnalyzing || !imageFile || !selectedModelCodigo}
               className="px-4 py-2.5 bg-amber disabled:opacity-40 text-black font-mono text-[10px] font-black uppercase rounded-lg hover:bg-amber-600 transition-all cursor-pointer"
             >
               {isAnalyzing ? 'Processando...' : 'Executar deteccao'}
@@ -370,12 +491,13 @@ export default function InspecaoImagens() {
           <div className="text-right min-w-[220px]">
             <p className="text-[9px] text-text-muted uppercase font-mono">Modelo carregado</p>
             <p className="text-[11px] text-text-primary font-mono">Modelo: {MODEL_PATH}</p>
+            <p className="text-[11px] text-text-secondary font-mono">Selecionado: {selectedModelCodigo || 'nenhum'}</p>
           </div>
         </div>
 
         <div className="bg-bg-panel border border-border rounded-2xl p-4 shrink-0">
           <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
-              <p className="text-[10px] font-black uppercase tracking-widest text-text-secondary">Selecao de componentes</p>
+              <p className="text-[10px] font-black uppercase tracking-widest text-text-secondary">Defeitos do modelo</p>
             <div className="flex gap-2">
               <button
                 type="button"
@@ -408,7 +530,7 @@ export default function InspecaoImagens() {
             ))}
 
             {!availableClasses.length && (
-              <p className="text-[10px] text-text-muted uppercase font-mono">Nenhuma classe disponivel em data.yaml</p>
+              <p className="text-[10px] text-text-muted uppercase font-mono">Selecione um modelo para carregar os defeitos do banco</p>
             )}
           </div>
         </div>
@@ -497,11 +619,34 @@ export default function InspecaoImagens() {
             <p className="text-[10px] uppercase font-black tracking-widest text-text-secondary">Estado atual</p>
             <p className="text-[12px] font-mono text-text-primary">{statusText}</p>
             {errorText && <p className="text-[11px] font-mono text-red-400">{errorText}</p>}
+            {savedPlaca && (
+              <p className="text-[11px] font-mono text-success-text">Placa persistida: #{savedPlaca.id} · {savedPlaca.modelo_codigo}</p>
+            )}
           </div>
 
           <div>
             <p className="text-[10px] uppercase font-black tracking-widest text-text-secondary">Quantidade de defeitos</p>
-            <p className="text-[12px] font-mono text-amber">{detections.length} defeitos detectados</p>
+            <p className="text-[12px] font-mono text-amber">{detections.length} defeitos temporarios</p>
+            <p className="text-[11px] font-mono text-text-secondary">Persistidos: {savedDetections.length}</p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={saveDetections}
+              disabled={isSaving || detections.length === 0 || !selectedModelCodigo || (savedDetections.length > 0 && savedDetections.length === detections.length)}
+              className="px-4 py-2.5 bg-success-text/90 text-black font-mono text-[10px] font-black uppercase rounded-lg hover:bg-success-text disabled:opacity-40 transition-all cursor-pointer"
+            >
+              {isSaving ? 'Salvando...' : 'Salvar defeitos detectados'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelDetections}
+              disabled={isAnalyzing && detections.length === 0}
+              className="px-4 py-2.5 bg-bg-elevated border border-critical-border text-critical-text font-mono text-[10px] font-black uppercase rounded-lg hover:bg-critical-bg transition-all cursor-pointer"
+            >
+              Cancelar
+            </button>
           </div>
         </div>
       </div>

--- a/app/page.js
+++ b/app/page.js
@@ -14,7 +14,7 @@ export default function HomePage() {
         const [defeitos, placas, modelos, health] = await Promise.all([
           api.getDefeitos(),
           api.getPlacas(),
-          fetch('/backend-api/modelos').then((response) => response.json()).then((payload) => payload.data || []),
+          api.getModelos(),
           api.getHealth(),
         ])
         setMetrics({

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,3 +22,5 @@ npm run db:migrate:deploy
 ```
 
 O fluxo oficial de banco é exclusivamente por migration.
+
+O endpoint `/api/detection` realiza apenas a analise temporaria. A persistencia de placa e defeitos acontece em `/api/detection/save`, somente depois de confirmacao explicita na interface.

--- a/backend/prisma/migrations/0004_add_defeito_metadata/migration.sql
+++ b/backend/prisma/migrations/0004_add_defeito_metadata/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE defeito
+  ADD COLUMN status_confirmacao VARCHAR(50) NOT NULL DEFAULT 'confirmado' AFTER classe_defeito,
+  ADD COLUMN tipo VARCHAR(50) NOT NULL DEFAULT 'imagem' AFTER status_confirmacao,
+  ADD COLUMN data_hora TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP AFTER tipo;
+
+CREATE INDEX idx_defeito_status_confirmacao ON defeito (status_confirmacao);
+CREATE INDEX idx_defeito_tipo ON defeito (tipo);

--- a/backend/src/app/api/detection/route.js
+++ b/backend/src/app/api/detection/route.js
@@ -1,6 +1,5 @@
 import { fail, ok } from '@/lib/http';
-import { resolvePlaca, persistDetections } from '@/lib/detection';
-import { serializeDefeito } from '@/lib/serializers';
+import { ensureModeloExiste } from '@/lib/detection';
 import { extractImagesFromZip, normalizeDetections, readAndValidateUpload } from '@/lib/upload';
 
 class AiServiceError extends Error {
@@ -105,6 +104,15 @@ function parseSelectedClasses(rawValue) {
   }
 }
 
+function parseModeloCodigo(formData) {
+  const values = [formData.get('modelo_codigo'), formData.get('modeloCodigo'), formData.get('placaCodigo')];
+  for (const value of values) {
+    const codigo = String(value || '').trim();
+    if (codigo) return codigo;
+  }
+  return '';
+}
+
 function filterDetectionsBySelectedClasses(detections, selectedClasses) {
   if (!Array.isArray(selectedClasses) || selectedClasses.length === 0) {
     return detections;
@@ -118,8 +126,7 @@ export async function POST(request) {
   try {
     const formData = await request.formData();
     const uploadedFile = formData.get('image') || formData.get('file');
-    const placaId = formData.get('placaId');
-    const placaCodigo = formData.get('placaCodigo');
+    const modeloCodigo = parseModeloCodigo(formData);
     const selectedClasses = parseSelectedClasses(formData.get('classes'));
 
     if (!uploadedFile) {
@@ -131,6 +138,13 @@ export async function POST(request) {
       uploadInfo = await readAndValidateUpload(uploadedFile);
     } catch (error) {
       return fail(error.message || 'Arquivo invalido', 400, 'INVALID_UPLOAD');
+    }
+
+    let modelo = null;
+    try {
+      modelo = await ensureModeloExiste(modeloCodigo);
+    } catch (error) {
+      return fail(error.message || 'Modelo nao encontrado', 404, 'NOT_FOUND');
     }
 
     const aiUrl = process.env.AI_SERVICE_URL || 'http://ai:5000';
@@ -148,14 +162,8 @@ export async function POST(request) {
       return fail(error.message || 'Arquivo .zip invalido', 400, 'INVALID_UPLOAD');
     }
 
-    const placa = await resolvePlaca({
-      placaId: placaId ? String(placaId) : null,
-      placaCodigo: placaCodigo ? String(placaCodigo) : null,
-    });
-
     const perImage = [];
     const flattenedDetections = [];
-    const persisted = [];
 
     for (const input of inputs) {
       let detections;
@@ -179,33 +187,28 @@ export async function POST(request) {
       detections = filterDetectionsBySelectedClasses(detections, selectedClasses);
 
       flattenedDetections.push(...detections);
-
-      const createdDefeitos = await persistDetections({
-        detections,
-        placa,
-        isVideo: uploadInfo.kind === 'video',
-      });
-
-      persisted.push(...createdDefeitos);
       perImage.push({
         fileName: input.name,
         detections,
-        savedDefeitos: createdDefeitos.map(serializeDefeito),
       });
     }
 
     return ok(
       {
         detections: flattenedDetections,
-        savedDefeitos: persisted.map(serializeDefeito),
+        savedDefeitos: [],
+        modelo: modelo ? { codigo: modelo.codigo } : null,
+        modeloCodigo: modelo.codigo,
+        inputType: uploadInfo.kind,
         itens: perImage,
       },
       {
         inputType: uploadInfo.kind,
         selectedClasses,
+        modeloCodigo: modelo.codigo,
         totalFiles: inputs.length,
         totalDetections: flattenedDetections.length,
-        totalPersisted: persisted.length,
+        totalPersisted: 0,
       }
     );
   } catch (error) {

--- a/backend/src/app/api/detection/save/route.js
+++ b/backend/src/app/api/detection/save/route.js
@@ -1,0 +1,63 @@
+import { fail, ok, readJson } from '@/lib/http';
+import { persistirDeteccoesConfirmadas } from '@/lib/detection';
+import { serializeDefeito, serializePlaca } from '@/lib/serializers';
+
+function normalizeModeloCodigo(body) {
+  const values = [body?.modelo_codigo, body?.modeloCodigo, body?.placaCodigo];
+  for (const value of values) {
+    const codigo = String(value || '').trim();
+    if (codigo) return codigo;
+  }
+  return '';
+}
+
+function normalizeSourceType(body) {
+  const tipo = String(body?.source_type || body?.sourceType || body?.tipo || 'imagem').trim();
+  return tipo === 'video' ? 'video' : 'imagem';
+}
+
+export async function POST(request) {
+  try {
+    const body = await readJson(request);
+    const modeloCodigo = normalizeModeloCodigo(body);
+    const detections = Array.isArray(body?.detections) ? body.detections : [];
+    const sourceType = normalizeSourceType(body);
+
+    if (!modeloCodigo) {
+      return fail('modelo_codigo e obrigatorio', 400, 'VALIDATION_ERROR');
+    }
+
+    if (detections.length === 0) {
+      return fail('Nenhuma deteccao para salvar', 400, 'VALIDATION_ERROR');
+    }
+
+    const persisted = await persistirDeteccoesConfirmadas({
+      modeloCodigo,
+      detections,
+      sourceType,
+    });
+
+    return ok(
+      {
+        modelo: { codigo: modeloCodigo },
+        placa: serializePlaca(persisted.placa),
+        savedDefeitos: persisted.defeitos.map(serializeDefeito),
+      },
+      {
+        totalPersisted: persisted.defeitos.length,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error.message === 'Modelo nao encontrado') {
+      return fail(error.message, 404, 'NOT_FOUND');
+    }
+
+    if (error.message === 'Deteccao sem classe valida' || error.message === 'modelo_codigo e obrigatorio') {
+      return fail(error.message, 400, 'VALIDATION_ERROR');
+    }
+
+    console.error('Erro ao salvar deteccoes:', error);
+    return fail('Erro ao salvar deteccoes', 500, 'PERSISTENCE_ERROR', error.message || null);
+  }
+}

--- a/backend/src/app/api/modelos/route.js
+++ b/backend/src/app/api/modelos/route.js
@@ -33,6 +33,15 @@ export async function POST(request) {
       return fail('codigo do modelo e obrigatorio', 400, 'VALIDATION_ERROR');
     }
 
+    const existente = await prisma.modelo.findUnique({
+      where: { codigo: codigoModelo },
+      select: { codigo: true },
+    });
+
+    if (existente) {
+      return fail('Codigo de modelo ja existe', 409, 'UNIQUE_CONSTRAINT');
+    }
+
     const modelo = await prisma.modelo.create({
       data: {
         codigo: codigoModelo,

--- a/backend/src/app/api/swagger/route.js
+++ b/backend/src/app/api/swagger/route.js
@@ -24,7 +24,7 @@ export async function GET() {
           responses: { 200: { description: 'IA disponivel' } },
         },
         post: {
-          summary: 'Processa imagem, ZIP ou video e persiste defeitos',
+          summary: 'Processa imagem, ZIP ou video e retorna analise temporaria',
           tags: ['Detection'],
           requestBody: {
             required: true,
@@ -34,15 +34,39 @@ export async function GET() {
                   type: 'object',
                   properties: {
                     file: { type: 'string', format: 'binary' },
-                    placaCodigo: { type: 'string' },
-                    placaId: { type: 'integer' },
+                    modelo_codigo: { type: 'string' },
                     classes: { type: 'string' },
                   },
                 },
               },
             },
           },
-          responses: { 200: { description: 'Deteccao concluida' } },
+          responses: { 200: { description: 'Analise concluida' } },
+        },
+      },
+      '/api/detection/save': {
+        post: {
+          summary: 'Salva placa e defeitos confirmados',
+          tags: ['Detection'],
+          requestBody: {
+            content: {
+              'application/json': {
+                example: {
+                  modelo_codigo: 'PCB-A001-L1',
+                  source_type: 'imagem',
+                  detections: [
+                    {
+                      class_id: 0,
+                      label: 'R/CFaltante',
+                      confidence: 0.97,
+                      bbox: [10, 20, 100, 120],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          responses: { 201: { description: 'Deteccoes salvas' } },
         },
       },
       '/api/modelos': {

--- a/backend/src/lib/detection.js
+++ b/backend/src/lib/detection.js
@@ -1,79 +1,101 @@
 import prisma from '@/lib/db';
 
-async function ensureModelo(codigo) {
-  return prisma.modelo.upsert({
-    where: { codigo },
-    update: {},
-    create: { codigo },
-  });
+function normalizeCodigo(value) {
+  return String(value || '').trim();
 }
 
-async function getOrCreateDefaultPlaca() {
-  const codigo = 'PCB-AUTO-DEFAULT';
-  await ensureModelo(codigo);
+function normalizeDetectionLabel(item) {
+  return normalizeCodigo(item?.label || item?.classe || item?.class || '');
+}
 
-  const existing = await prisma.placa.findFirst({
-    where: { modeloCodigo: codigo },
-  });
-  if (existing) return existing;
+function normalizeTipo(item, sourceType) {
+  if (sourceType === 'video') return 'video';
+  if (item?.frame !== undefined && item?.frame !== null) return 'video';
+  return 'imagem';
+}
 
-  return prisma.placa.create({
+function normalizeDataHora(item, tipo) {
+  if (tipo !== 'video') return null;
+
+  const rawValue = item?.data_hora || item?.dataHora || null;
+  if (!rawValue) return undefined;
+
+  const dataHora = new Date(rawValue);
+  if (Number.isNaN(dataHora.getTime())) {
+    throw new Error('data_hora invalida na deteccao');
+  }
+
+  return dataHora;
+}
+
+export async function ensureModeloExiste(modeloCodigo, client = prisma) {
+  const codigo = normalizeCodigo(modeloCodigo);
+  if (!codigo) {
+    throw new Error('modelo_codigo e obrigatorio');
+  }
+
+  const modelo = await client.modelo.findUnique({ where: { codigo } });
+  if (!modelo) {
+    throw new Error('Modelo nao encontrado');
+  }
+
+  return modelo;
+}
+
+export async function criarPlacaParaModelo(modeloCodigo, client = prisma) {
+  const codigo = normalizeCodigo(modeloCodigo);
+  if (!codigo) {
+    throw new Error('modelo_codigo e obrigatorio');
+  }
+
+  await ensureModeloExiste(codigo, client);
+
+  return client.placa.create({
     data: { modeloCodigo: codigo },
+    include: { modelo: true },
   });
 }
 
-export async function resolvePlaca({ placaId, placaCodigo }) {
-  if (placaId) {
-    const id = Number(placaId);
-    const byId = Number.isInteger(id) ? await prisma.placa.findUnique({ where: { id } }) : null;
-    if (byId) return byId;
+export async function persistirDeteccoesConfirmadas({ modeloCodigo, detections, sourceType = 'imagem' }) {
+  const codigo = normalizeCodigo(modeloCodigo);
+  if (!codigo) {
+    throw new Error('modelo_codigo e obrigatorio');
   }
 
-  if (placaCodigo) {
-    const codigo = String(placaCodigo).trim();
-    if (codigo) {
-      await ensureModelo(codigo);
-      const existing = await prisma.placa.findFirst({
-        where: { modeloCodigo: codigo },
-      });
-      if (existing) return existing;
-
-      return prisma.placa.create({
-        data: { modeloCodigo: codigo },
-      });
-    }
-  }
-
-  return getOrCreateDefaultPlaca();
-}
-
-export async function persistDetections({ detections, placa, isVideo = false }) {
   if (!Array.isArray(detections) || detections.length === 0) {
-    return [];
+    return { placa: null, defeitos: [] };
   }
 
-  const created = [];
+  return prisma.$transaction(async (client) => {
+    const placa = await criarPlacaParaModelo(codigo, client);
+    const defeitos = [];
 
-  for (const item of detections) {
-    const classeDefeito = String(item.label || 'defeito-nao-classificado');
-    const hasVideoFrame = item.frame !== undefined && item.frame !== null;
-    const tipo = isVideo || hasVideoFrame ? 'video' : 'imagem';
+    for (const item of detections) {
+      const classeDefeito = normalizeDetectionLabel(item);
+      if (!classeDefeito) {
+        throw new Error('Deteccao sem classe valida');
+      }
 
-    const defeito = await prisma.defeito.create({
-      data: {
-        placaId: placa.id,
-        classeDefeito,
-        statusConfirmacao: 'confirmado',
-        tipo,
-        ...(tipo === 'imagem' ? { dataHora: null } : {}),
-      },
-      include: {
-        placa: true,
-      },
-    });
+      const tipo = normalizeTipo(item, sourceType);
+      const dataHora = normalizeDataHora(item, tipo);
 
-    created.push(defeito);
-  }
+      const defeito = await client.defeito.create({
+        data: {
+          placaId: placa.id,
+          classeDefeito,
+          statusConfirmacao: 'confirmado',
+          tipo,
+          ...(tipo === 'imagem' ? { dataHora: null } : {}),
+          ...(tipo === 'video' && dataHora ? { dataHora } : {}),
+        },
+        include: {
+          placa: true,
+        },
+      });
 
-  return created;
+      defeitos.push(defeito);
+    }
+
+    return { placa, defeitos };
+  });
 }

--- a/components/AppShell.js
+++ b/components/AppShell.js
@@ -16,6 +16,7 @@ export default function AppShell({ children, breadcrumb }) {
       { name: 'Vídeos',    icon: <path d="M23 7l-7 5 7 5V7zM1 5h14v14H1V5z"/>, path: '/videos' },
     ],
     controle: [
+      { name: 'Modelos',    icon: <path d="M12 2l8 4v12l-8 4-8-4V6z"/>, path: '/configuracoes' },
       { name: 'Defeitos',   icon: <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>, path: '/defeitos' },
     ],
   }

--- a/services/api.js
+++ b/services/api.js
@@ -58,13 +58,21 @@ export const api = {
   getHealth: () =>
     request('/health'),
 
+  // Modelos
+  getModelos: () =>
+    request('/modelos'),
+
+  criarModelo: (body) =>
+    requestBody('POST', '/modelos', body),
+
   // Dashboard (usa os endpoints existentes para montar as métricas)
   getDashboard: async () => {
-    const [defeitos, placas] = await Promise.all([
+    const [defeitos, placas, modelos] = await Promise.all([
       request('/defeitos'),
       request('/placas'),
+      request('/modelos'),
     ])
-    return { defeitos, placas }
+    return { defeitos, placas, modelos }
   },
 
   // Placas
@@ -96,5 +104,8 @@ export const api = {
   // Detecção por imagem (IA)
   analisarImagem: (formData) =>
     requestForm('/detection', formData),
+
+  salvarDeteccoes: (body) =>
+    requestBody('POST', '/detection/save', body),
 
 }


### PR DESCRIPTION
Closes #49

## O que foi feito
- Cadastro/listagem de modelos na tela administrativa
- Fluxo de detecção com seleção de modelo
- Salvamento explícito de defeitos
- Ajuste de persistência no banco
- Correções de contrato entre frontend, backend e Prisma