### PR TITLE
feat: adequacao da estrutura de banco de dados para relatorios (issue…

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -158,3 +158,16 @@ Cria o relatorio no inicio da execucao, associa o usuario autenticado como criad
 ### `PATCH /api/relatorios/:id`
 
 Atualiza dados administrativos do relatorio e registra `id_usuario_ultimo_acesso` sem alterar o criador original.
+
+**Restrições:**
+- Apenas usuários com cargo `ADMINISTRADOR` podem acessar esta rota.
+- `id_usuario_criador` é imutável e será ignorado se enviado no body.
+- `id_usuario_ultimo_acesso` é preenchido automaticamente com o ID do administrador autenticado.
+
+**Body:**
+```json
+{
+  "placa_id": 12
+}
+```
+

--- a/backend/DATABASE.md
+++ b/backend/DATABASE.md
@@ -50,7 +50,19 @@ usuario.id
 - `criado_em TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`
 - `atualizado_em TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`
 
-`id_usuario_criador` identifica o usuario que executou o lote e deve ser preenchido automaticamente na criacao do relatorio. Esse campo nao deve ser alterado em atualizacoes. `id_usuario_ultimo_acesso` registra o ultimo administrador que modificou o relatorio.
+#### Regras de Rastreabilidade (Issue #28)
+
+1. **`id_usuario_criador`**:
+   - Identifica o usuário (operador) que executou o lote ou salvou a detecção.
+   - Deve ser preenchido **automaticamente** no momento da criação.
+   - **Nunca** deve ser alterado em operações subsequentes (imutabilidade).
+2. **`id_usuario_ultimo_acesso`**:
+   - Registra o ID do último administrador que realizou modificações manuais no relatório.
+   - Pode ser `NULL` se o relatório nunca foi editado após a criação.
+   - Deve ser atualizado automaticamente em qualquer `UPDATE` via API administrativa.
+3. **Remoção de Campos Legados**:
+   - Os campos `usuario_id` e `status` foram removidos desta tabela para evitar redundância e centralizar a rastreabilidade nos novos campos de FK.
+
 
 Relacionamentos:
 

--- a/tests/backend/issue28_integrity.test.js
+++ b/tests/backend/issue28_integrity.test.js
@@ -1,0 +1,91 @@
+import jwt from 'jsonwebtoken';
+import { PATCH as atualizarRelatorio } from '../../backend/src/app/api/relatorios/[id]/route';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'inspectai-chave-super-secreta-2026';
+
+jest.mock('@/lib/db', () => {
+  const db = {
+    relatorio: {
+      update: jest.fn(),
+    },
+  };
+  return {
+    __esModule: true,
+    default: db,
+    prisma: db,
+  };
+});
+
+const mockPrisma = jest.requireMock('@/lib/db').default;
+
+function makeToken(payload) {
+  return jwt.sign(payload, JWT_SECRET);
+}
+
+function makeRequest(url, body, payload) {
+  return new Request(url, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${makeToken(payload)}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Issue #28: Integridade e Rastreabilidade do Relatório', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Garante que id_usuario_criador NUNCA é alterado, mesmo se enviado no body', async () => {
+    const adminPayload = { id: 2, nome: 'Admin', cargo: 'ADMINISTRADOR' };
+    
+    mockPrisma.relatorio.update.mockResolvedValue({
+      id: 100,
+      placaId: 10,
+      idUsuarioCriador: 5, // Mantém o original
+      idUsuarioUltimoAcesso: 2, // Atualiza para o admin que está editando
+      criadoEm: new Date(),
+      atualizadoEm: new Date(),
+    });
+
+    const req = makeRequest(
+      'http://localhost:3000/api/relatorios/100',
+      {
+        id_usuario_criador: 999, // Tentativa maliciosa de mudar o criador
+        placa_id: 10
+      },
+      adminPayload
+    );
+
+    await atualizarRelatorio(req, { params: Promise.resolve({ id: '100' }) });
+
+    // Verifica que o Prisma recebeu apenas os campos permitidos
+    const updateCall = mockPrisma.relatorio.update.mock.calls[0][0];
+    expect(updateCall.data).toHaveProperty('idUsuarioUltimoAcesso', 2);
+    expect(updateCall.data).toHaveProperty('placaId', 10);
+    expect(updateCall.data).not.toHaveProperty('idUsuarioCriador');
+    expect(updateCall.data).not.toHaveProperty('id_usuario_criador');
+  });
+
+  it('Garante que id_usuario_ultimo_acesso é registrado corretamente em modificações', async () => {
+    const adminPayload = { id: 3, nome: 'Supervisor', cargo: 'ADMINISTRADOR' };
+    
+    mockPrisma.relatorio.update.mockResolvedValue({
+      id: 100,
+      idUsuarioUltimoAcesso: 3,
+    });
+
+    const req = makeRequest(
+      'http://localhost:3000/api/relatorios/100',
+      { placa_id: 11 },
+      adminPayload
+    );
+
+    await atualizarRelatorio(req, { params: Promise.resolve({ id: '100' }) });
+
+    const updateCall = mockPrisma.relatorio.update.mock.calls[0][0];
+    expect(updateCall.data).toHaveProperty('idUsuarioUltimoAcesso', 3);
+  });
+});


### PR DESCRIPTION
 ## Descrição
Ajuste da tabela de relatórios para suportar a rastreabilidade dos responsáveis pela criação e modificação, garantindo a integridade dos dados em execuções individuais e em lote.
## Mudanças
- Implementação de `id_usuario_criador` (FK) e `id_usuario_ultimo_acesso` (FK).
- Remoção dos campos redundantes/legados `usuario_id` e `status`.
- Atualização da documentação técnica em `backend/DATABASE.md` e `API_CONTRACT.md`.
- Adição de testes de integração em `tests/backend/issue28_integrity.test.js` para validar as regras de negócio.
Fixed #28